### PR TITLE
[PoC] Pass through Proxy Protocol TLVs to upstream

### DIFF
--- a/envoy/network/proxy_protocol.h
+++ b/envoy/network/proxy_protocol.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "envoy/network/address.h"
-
 #include <vector>
+
+#include "envoy/network/address.h"
 
 namespace Envoy {
 namespace Network {

--- a/envoy/network/proxy_protocol.h
+++ b/envoy/network/proxy_protocol.h
@@ -13,11 +13,13 @@ struct ProxyProtocolTLV {
   std::string value;
 };
 
+using ProxyProtocolTLVVector = std::vector<ProxyProtocolTLV>;
+using ProxyProtocolTLVVectorPtr = std::shared_ptr<std::vector<ProxyProtocolTLV>>;
+
 struct ProxyProtocolData {
   const Network::Address::InstanceConstSharedPtr src_addr_;
   const Network::Address::InstanceConstSharedPtr dst_addr_;
-  mutable std::shared_ptr<std::vector<ProxyProtocolTLV>> tlv_vector_ 
-  = std::make_shared<std::vector<ProxyProtocolTLV>>();
+  mutable ProxyProtocolTLVVectorPtr tlv_vector_ = std::make_shared<ProxyProtocolTLVVector>();
   std::string asStringForHash() const {
     return std::string(src_addr_ ? src_addr_->asString() : "null") +
            (dst_addr_ ? dst_addr_->asString() : "null");

--- a/envoy/network/proxy_protocol.h
+++ b/envoy/network/proxy_protocol.h
@@ -16,7 +16,8 @@ struct ProxyProtocolTLV {
 struct ProxyProtocolData {
   const Network::Address::InstanceConstSharedPtr src_addr_;
   const Network::Address::InstanceConstSharedPtr dst_addr_;
-  std::vector<ProxyProtocolTLV> tlv_vector_ = {};
+  mutable std::shared_ptr<std::vector<ProxyProtocolTLV>> tlv_vector_ 
+  = std::make_shared<std::vector<ProxyProtocolTLV>>();
   std::string asStringForHash() const {
     return std::string(src_addr_ ? src_addr_->asString() : "null") +
            (dst_addr_ ? dst_addr_->asString() : "null");

--- a/envoy/network/proxy_protocol.h
+++ b/envoy/network/proxy_protocol.h
@@ -2,12 +2,21 @@
 
 #include "envoy/network/address.h"
 
+#include <vector>
+
 namespace Envoy {
 namespace Network {
+
+struct ProxyProtocolTLV {
+  uint8_t type;
+  std::string key;
+  std::string value;
+};
 
 struct ProxyProtocolData {
   const Network::Address::InstanceConstSharedPtr src_addr_;
   const Network::Address::InstanceConstSharedPtr dst_addr_;
+  std::vector<ProxyProtocolTLV> tlv_vector_ = {};
   std::string asStringForHash() const {
     return std::string(src_addr_ ? src_addr_->asString() : "null") +
            (dst_addr_ ? dst_addr_->asString() : "null");

--- a/source/common/network/BUILD
+++ b/source/common/network/BUILD
@@ -432,6 +432,7 @@ envoy_cc_library(
         "//envoy/network:proxy_protocol_options_lib",
         "//envoy/network:transport_socket_interface",
         "//envoy/stream_info:filter_state_interface",
+        "//source/common/common:minimal_logger_lib",
         "//source/common/common:scalar_to_byte_vector_lib",
         "//source/common/common:utility_lib",
     ],

--- a/source/common/network/proxy_protocol_filter_state.h
+++ b/source/common/network/proxy_protocol_filter_state.h
@@ -12,11 +12,11 @@ namespace Network {
 class ProxyProtocolFilterState : public StreamInfo::FilterState::Object {
 public:
   ProxyProtocolFilterState(Network::ProxyProtocolData options) : options_(options) {}
-  Network::ProxyProtocolData& value() { return options_; }
+  const Network::ProxyProtocolData& value() const { return options_; }
   static const std::string& key();
 
 private:
-  Network::ProxyProtocolData options_;
+  const Network::ProxyProtocolData options_;
 };
 
 } // namespace Network

--- a/source/common/network/proxy_protocol_filter_state.h
+++ b/source/common/network/proxy_protocol_filter_state.h
@@ -12,11 +12,11 @@ namespace Network {
 class ProxyProtocolFilterState : public StreamInfo::FilterState::Object {
 public:
   ProxyProtocolFilterState(Network::ProxyProtocolData options) : options_(options) {}
-  const Network::ProxyProtocolData& value() const { return options_; }
+  Network::ProxyProtocolData& value() { return options_; }
   static const std::string& key();
 
 private:
-  const Network::ProxyProtocolData options_;
+  Network::ProxyProtocolData options_;
 };
 
 } // namespace Network

--- a/source/common/network/transport_socket_options_impl.cc
+++ b/source/common/network/transport_socket_options_impl.cc
@@ -89,8 +89,8 @@ TransportSocketOptionsUtility::fromFilterState(const StreamInfo::FilterState& fi
   }
 
   if (filter_state.hasData<ProxyProtocolFilterState>(ProxyProtocolFilterState::key())) {
-    const auto& proxy_protocol_filter_state =
-        filter_state.getDataReadOnly<ProxyProtocolFilterState>(ProxyProtocolFilterState::key());
+    auto& proxy_protocol_filter_state =
+        filter_state.getDataMutable<ProxyProtocolFilterState>(ProxyProtocolFilterState::key());
     proxy_protocol_options.emplace(proxy_protocol_filter_state.value());
     needs_transport_socket_options = true;
   }

--- a/source/common/network/transport_socket_options_impl.cc
+++ b/source/common/network/transport_socket_options_impl.cc
@@ -1,19 +1,19 @@
 #include "source/common/network/transport_socket_options_impl.h"
 
 #include <cstdint>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-#include <iostream>
 
+#include "source/common/common/logger.h"
 #include "source/common/common/scalar_to_byte_vector.h"
 #include "source/common/common/utility.h"
 #include "source/common/network/application_protocol.h"
 #include "source/common/network/proxy_protocol_filter_state.h"
 #include "source/common/network/upstream_server_name.h"
 #include "source/common/network/upstream_subject_alt_names.h"
-#include "source/common/common/logger.h"
 
 namespace Envoy {
 namespace Network {

--- a/source/common/network/transport_socket_options_impl.cc
+++ b/source/common/network/transport_socket_options_impl.cc
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 #include "source/common/common/scalar_to_byte_vector.h"
 #include "source/common/common/utility.h"
@@ -12,6 +13,7 @@
 #include "source/common/network/proxy_protocol_filter_state.h"
 #include "source/common/network/upstream_server_name.h"
 #include "source/common/network/upstream_subject_alt_names.h"
+#include "source/common/common/logger.h"
 
 namespace Envoy {
 namespace Network {
@@ -89,8 +91,10 @@ TransportSocketOptionsUtility::fromFilterState(const StreamInfo::FilterState& fi
   }
 
   if (filter_state.hasData<ProxyProtocolFilterState>(ProxyProtocolFilterState::key())) {
-    auto& proxy_protocol_filter_state =
-        filter_state.getDataMutable<ProxyProtocolFilterState>(ProxyProtocolFilterState::key());
+    // ENVOY_LOG(debug, "XXX create options");
+    std::cout << "XXX create options" << std::endl;
+    const auto& proxy_protocol_filter_state =
+        filter_state.getDataReadOnly<ProxyProtocolFilterState>(ProxyProtocolFilterState::key());
     proxy_protocol_options.emplace(proxy_protocol_filter_state.value());
     needs_transport_socket_options = true;
   }

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -377,7 +377,7 @@ Network::FilterStatus Filter::initializeUpstreamConnection() {
               downstreamConnection()->connectionInfoProvider().localAddress()}),
           StreamInfo::FilterState::StateType::Mutable,
           StreamInfo::FilterState::LifeSpan::Connection);
-          ENVOY_LOG(debug, "XXX Filter::initializeUpstreamConnection in tcp_proxy");
+      ENVOY_LOG(debug, "XXX Filter::initializeUpstreamConnection in tcp_proxy");
     }
     transport_socket_options_ = Network::TransportSocketOptionsUtility::fromFilterState(
         downstreamConnection()->streamInfo().filterState());

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -375,8 +375,9 @@ Network::FilterStatus Filter::initializeUpstreamConnection() {
           std::make_unique<Network::ProxyProtocolFilterState>(Network::ProxyProtocolData{
               downstreamConnection()->connectionInfoProvider().remoteAddress(),
               downstreamConnection()->connectionInfoProvider().localAddress()}),
-          StreamInfo::FilterState::StateType::ReadOnly,
+          StreamInfo::FilterState::StateType::Mutable,
           StreamInfo::FilterState::LifeSpan::Connection);
+          ENVOY_LOG(debug, "XXX Filter::initializeUpstreamConnection");
     }
     transport_socket_options_ = Network::TransportSocketOptionsUtility::fromFilterState(
         downstreamConnection()->streamInfo().filterState());

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -377,7 +377,7 @@ Network::FilterStatus Filter::initializeUpstreamConnection() {
               downstreamConnection()->connectionInfoProvider().localAddress()}),
           StreamInfo::FilterState::StateType::Mutable,
           StreamInfo::FilterState::LifeSpan::Connection);
-          ENVOY_LOG(debug, "XXX Filter::initializeUpstreamConnection");
+          ENVOY_LOG(debug, "XXX Filter::initializeUpstreamConnection in tcp_proxy");
     }
     transport_socket_options_ = Network::TransportSocketOptionsUtility::fromFilterState(
         downstreamConnection()->streamInfo().filterState());

--- a/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
+++ b/source/extensions/common/proxy_protocol/proxy_protocol_header.cc
@@ -120,7 +120,8 @@ void generateV2LocalHeader(Buffer::Instance& out) {
   out.add(addr_fam_protocol_and_length, 4);
 }
 
-void generateV2HeaderAndTLV(const Network::ProxyProtocolData& prox_proto_data, Buffer::Instance& out) {
+void generateV2HeaderAndTLV(const Network::ProxyProtocolData& prox_proto_data,
+                            Buffer::Instance& out) {
   uint16_t extension_length = 0;
   for (Network::ProxyProtocolTLV& tlv : *prox_proto_data.tlv_vector_) {
     extension_length += 3 + tlv.value.size();

--- a/source/extensions/common/proxy_protocol/proxy_protocol_header.h
+++ b/source/extensions/common/proxy_protocol/proxy_protocol_header.h
@@ -64,7 +64,8 @@ void generateV2LocalHeader(Buffer::Instance& out);
 
 // Generates the v2 PROXY protocol header and the TLV vector into the specified buffer.
 // TODO: fix const.
-void generateV2HeaderAndTLV(const Network::ProxyProtocolData& prox_proto_data, Buffer::Instance& out);
+void generateV2HeaderAndTLV(const Network::ProxyProtocolData& prox_proto_data,
+                            Buffer::Instance& out);
 
 } // namespace ProxyProtocol
 } // namespace Common

--- a/source/extensions/common/proxy_protocol/proxy_protocol_header.h
+++ b/source/extensions/common/proxy_protocol/proxy_protocol_header.h
@@ -4,6 +4,7 @@
 #include "envoy/config/core/v3/proxy_protocol.pb.h"
 #include "envoy/network/address.h"
 #include "envoy/network/connection.h"
+#include "envoy/network/proxy_protocol.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -50,7 +51,7 @@ void generateV1Header(const Network::Address::Ip& source_address,
 // TCP is assumed as the transport protocol
 void generateV2Header(const std::string& src_addr, const std::string& dst_addr, uint32_t src_port,
                       uint32_t dst_port, Network::Address::IpVersion ip_version,
-                      Buffer::Instance& out);
+                      uint16_t extension_length, Buffer::Instance& out);
 void generateV2Header(const Network::Address::Ip& source_address,
                       const Network::Address::Ip& dest_address, Buffer::Instance& out);
 
@@ -60,6 +61,10 @@ void generateProxyProtoHeader(const envoy::config::core::v3::ProxyProtocolConfig
 
 // Generates the v2 PROXY protocol local command header and adds it to the specified buffer
 void generateV2LocalHeader(Buffer::Instance& out);
+
+// Generates the v2 PROXY protocol header and the TLV vector into the specified buffer.
+// TODO: fix const.
+void generateV2HeaderAndTLV(const Network::ProxyProtocolData& prox_proto_data, Buffer::Instance& out);
 
 } // namespace ProxyProtocol
 } // namespace Common

--- a/source/extensions/filters/listener/proxy_protocol/BUILD
+++ b/source/extensions/filters/listener/proxy_protocol/BUILD
@@ -30,6 +30,7 @@ envoy_cc_library(
         "//source/common/common:safe_memcpy_lib",
         "//source/common/common:utility_lib",
         "//source/common/network:address_lib",
+        "//source/common/network:proxy_protocol_filter_state_lib",
         "//source/common/network:utility_lib",
         "//source/extensions/common/proxy_protocol:proxy_protocol_header_lib",
         "@envoy_api//envoy/extensions/filters/listener/proxy_protocol/v3:pkg_cc_proto",

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -65,10 +65,17 @@ void UpstreamProxyProtocolSocket::generateHeaderV1() {
 }
 
 void UpstreamProxyProtocolSocket::generateHeaderV2() {
+  ENVOY_LOG(debug, fmt::format("XXX generateHeaderV2: {}", 
+    callbacks_->connection().streamInfo().dynamicMetadata().DebugString()));  
   if (!options_ || !options_->proxyProtocolOptions().has_value()) {
+    ENVOY_LOG(debug, fmt::format("XXX UpstreamProxyProtocol: {}", header_buffer_.toString()));
     Common::ProxyProtocol::generateV2LocalHeader(header_buffer_);
   } else {
+      
     const auto options = options_->proxyProtocolOptions().value();
+    ENVOY_LOG(debug, fmt::format("XXX UpstreamProxyProtocol: {}, options: src {}, dst {}",
+      header_buffer_.toString(), 
+      options.src_addr_->ip()->addressAsString(), options.dst_addr_->ip()->addressAsString()));
     Common::ProxyProtocol::generateV2Header(*options.src_addr_->ip(), *options.dst_addr_->ip(),
                                             header_buffer_);
   }

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -65,19 +65,22 @@ void UpstreamProxyProtocolSocket::generateHeaderV1() {
 }
 
 void UpstreamProxyProtocolSocket::generateHeaderV2() {
-  ENVOY_LOG(debug, fmt::format("XXX generateHeaderV2: {}", 
-    callbacks_->connection().streamInfo().dynamicMetadata().DebugString()));  
+  ENVOY_LOG(debug,
+            fmt::format("XXX generateHeaderV2: {}",
+                        callbacks_->connection().streamInfo().dynamicMetadata().DebugString()));
   if (!options_ || !options_->proxyProtocolOptions().has_value()) {
     ENVOY_LOG(debug, fmt::format("XXX UpstreamProxyProtocol: {}", header_buffer_.toString()));
     Common::ProxyProtocol::generateV2LocalHeader(header_buffer_);
   } else {
-      
+
     const auto options = options_->proxyProtocolOptions().value();
-    ENVOY_LOG(debug, fmt::format("XXX UpstreamProxyProtocol: {}, options: src {}, dst {}",
-      header_buffer_.toString(), 
-      options.src_addr_->ip()->addressAsString(), options.dst_addr_->ip()->addressAsString()));
+    ENVOY_LOG(debug,
+              fmt::format("XXX UpstreamProxyProtocol: {}, options: src {}, dst {}",
+                          header_buffer_.toString(), options.src_addr_->ip()->addressAsString(),
+                          options.dst_addr_->ip()->addressAsString()));
     if (!options.tlv_vector_->empty()) {
-      ENVOY_LOG(debug, fmt::format("XXX Got TLV on upstream: first type: {}", options.tlv_vector_->front().key));
+      ENVOY_LOG(debug, fmt::format("XXX Got TLV on upstream: first type: {}",
+                                   options.tlv_vector_->front().key));
     }
     Common::ProxyProtocol::generateV2HeaderAndTLV(options, header_buffer_);
   }

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -76,6 +76,9 @@ void UpstreamProxyProtocolSocket::generateHeaderV2() {
     ENVOY_LOG(debug, fmt::format("XXX UpstreamProxyProtocol: {}, options: src {}, dst {}",
       header_buffer_.toString(), 
       options.src_addr_->ip()->addressAsString(), options.dst_addr_->ip()->addressAsString()));
+    if (!options.tlv_vector_->empty()) {
+      ENVOY_LOG(debug, fmt::format("XXX Got TLV on upstream: first type: {}", options.tlv_vector_->front().key));
+    }
     Common::ProxyProtocol::generateV2Header(*options.src_addr_->ip(), *options.dst_addr_->ip(),
                                             header_buffer_);
   }

--- a/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
+++ b/source/extensions/transport_sockets/proxy_protocol/proxy_protocol.cc
@@ -79,8 +79,7 @@ void UpstreamProxyProtocolSocket::generateHeaderV2() {
     if (!options.tlv_vector_->empty()) {
       ENVOY_LOG(debug, fmt::format("XXX Got TLV on upstream: first type: {}", options.tlv_vector_->front().key));
     }
-    Common::ProxyProtocol::generateV2Header(*options.src_addr_->ip(), *options.dst_addr_->ip(),
-                                            header_buffer_);
+    Common::ProxyProtocol::generateV2HeaderAndTLV(options, header_buffer_);
   }
 }
 


### PR DESCRIPTION
This PoC creates `Network::ProxyProtocolFilterState` and manipulate the TLVs in the proxy protocol listener filter instead of creating it in the TCP proxy. Thus when `ProxyProtocolUpstreamTransport` is created with an option, the option will include the parsed TLVs, correctly generating the header with TLVs.